### PR TITLE
Trim input before register/login

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
     <script>
         document.getElementById('loginForm').addEventListener('submit', function(event) {
             event.preventDefault();
-            const username = event.target.username.value;
-            const password = event.target.password.value;
+            const username = event.target.username.value.trim();
+            const password = event.target.password.value.trim();
 
             if (!username || !password) {
                 alert('Please enter both username and password.');

--- a/signup.html
+++ b/signup.html
@@ -31,9 +31,9 @@
     <script>
         document.getElementById('signupForm').addEventListener('submit', function(event) {
             event.preventDefault();
-            const username = event.target.username.value;
-            const password = event.target.password.value;
-            const email = event.target.email.value;
+            const username = event.target.username.value.trim();
+            const password = event.target.password.value.trim();
+            const email = event.target.email.value.trim();
 
             // Basic validation (can be more extensive)
             if (!username || !password || !email) {

--- a/userdata.js
+++ b/userdata.js
@@ -15,6 +15,9 @@ function setUserData(data) {
 }
 
 function registerUser(username, password, email) {
+    username = username.trim();
+    password = password.trim();
+    email = email.trim();
     const users = getUserData();
 
     // Check for existing username or email
@@ -34,6 +37,8 @@ function registerUser(username, password, email) {
 }
 
 function loginUser(username, password) {
+    username = username.trim();
+    password = password.trim();
     const users = getUserData();
     if (users[username] && users[username].password === password) { // In a real app, compare hashed passwords!
         return { success: true, message: 'Login successful.' };


### PR DESCRIPTION
## Summary
- trim username/password/email before calling user APIs in login & signup forms
- ensure registerUser and loginUser functions trim their arguments

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_6841509b1ed483279a2f718e9348f40c